### PR TITLE
CurrentScope = null in EndRequest

### DIFF
--- a/src/LightInject.Web/LightInject.Web.cs
+++ b/src/LightInject.Web/LightInject.Web.cs
@@ -118,7 +118,10 @@ namespace LightInject.Web
             var scopeManager = (ScopeManager)application.Context.Items["ScopeManager"];
             if (scopeManager != null)
             {
-                scopeManager.CurrentScope.Dispose();
+                if (scopeManager.CurrentScope != null)
+                {
+                    scopeManager.CurrentScope.Dispose();
+                }
             }
         }
 


### PR DESCRIPTION
Sometimes we get CurrentScope = null and therefore get a NRE. Null check to remedy this.
